### PR TITLE
Preparing for Ruby 3.5

### DIFF
--- a/rubycas-client.gemspec
+++ b/rubycas-client.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency 'rexml'
+  s.add_runtime_dependency 'pstore'
 
   s.add_development_dependency 'actionpack', '>= 5.2', '< 7.1'
   s.add_development_dependency 'activerecord', '>= 5.2', '< 7.1'


### PR DESCRIPTION
Need to add `pstore` as a direct gem dependency to resolve the following warning:

> /.../.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rubycas-client-537699799ffa/lib/casclient/tickets/storage.rb:1: warning: /.../.rbenv/versions/3.3.5/lib/ruby/3.3.0/pstore.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add pstore to your Gemfile or gemspec to silence this warning.